### PR TITLE
Add gazebo-ros-control packages to rosdep keys.

### DIFF
--- a/gazebo8/releases/jade.yaml
+++ b/gazebo8/releases/jade.yaml
@@ -6,6 +6,5 @@ gazebo_ros:
   ubuntu: [ros-jade-gazebo8-ros]
 gazebo_ros_control:
   ubuntu: [ros-jade-gazebo8-ros-control]
-  debian: [ros-jade-gazebo8-ros-control]
 gazebo_ros_pkgs:
   ubuntu: [ros-jade-gazebo8-ros-pkgs]

--- a/gazebo8/releases/jade.yaml
+++ b/gazebo8/releases/jade.yaml
@@ -4,5 +4,8 @@ gazebo_plugins:
   ubuntu: [ros-jade-gazebo8-plugins]
 gazebo_ros:
   ubuntu: [ros-jade-gazebo8-ros]
+gazebo_ros_control:
+  ubuntu: [ros-jade-gazebo8-ros-control]
+  debian: [ros-jade-gazebo8-ros-control]
 gazebo_ros_pkgs:
   ubuntu: [ros-jade-gazebo8-ros-pkgs]

--- a/gazebo8/releases/kinetic.yaml
+++ b/gazebo8/releases/kinetic.yaml
@@ -7,6 +7,9 @@ gazebo_plugins:
 gazebo_ros:
   ubuntu: [ros-kinetic-gazebo8-ros]
   debian: [ros-kinetic-gazebo8-ros]
+gazebo_ros_control:
+  ubuntu: [ros-kinetic-gazebo8-ros-control]
+  debian: [ros-kinetic-gazebo8-ros-control]
 gazebo_ros_pkgs:
   ubuntu: [ros-kinetic-gazebo8-ros-pkgs]
   debian: [ros-kinetic-gazebo8-ros-pkgs]

--- a/gazebo8/releases/lunar.yaml
+++ b/gazebo8/releases/lunar.yaml
@@ -7,6 +7,9 @@ gazebo_plugins:
 gazebo_ros:
   ubuntu: [ros-lunar-gazebo8-ros]
   debian: [ros-lunar-gazebo8-ros]
+gazebo_ros_control:
+  ubuntu: [ros-lunar-gazebo8-ros-control]
+  debian: [ros-lunar-gazebo8-ros-control]
 gazebo_ros_pkgs:
   ubuntu: [ros-lunar-gazebo8-ros-pkgs]
   debian: [ros-lunar-gazebo8-ros-pkgs]

--- a/gazebo9/releases/jade.yaml
+++ b/gazebo9/releases/jade.yaml
@@ -4,5 +4,7 @@ gazebo_plugins:
   ubuntu: [ros-jade-gazebo9-plugins]
 gazebo_ros:
   ubuntu: [ros-jade-gazebo9-ros]
+gazebo_ros_control:
+  ubuntu: [ros-jade-gazebo9-ros-control]
 gazebo_ros_pkgs:
   ubuntu: [ros-jade-gazebo9-ros-pkgs]

--- a/gazebo9/releases/kinetic.yaml
+++ b/gazebo9/releases/kinetic.yaml
@@ -7,6 +7,9 @@ gazebo_plugins:
 gazebo_ros:
   ubuntu: [ros-kinetic-gazebo9-ros]
   debian: [ros-kinetic-gazebo9-ros]
+gazebo_ros_control:
+  ubuntu: [ros-kinetic-gazebo9-ros-control]
+  debian: [ros-kinetic-gazebo9-ros-control]
 gazebo_ros_pkgs:
   ubuntu: [ros-kinetic-gazebo9-ros-pkgs]
   debian: [ros-kinetic-gazebo9-ros-pkgs]

--- a/gazebo9/releases/lunar.yaml
+++ b/gazebo9/releases/lunar.yaml
@@ -7,6 +7,9 @@ gazebo_plugins:
 gazebo_ros:
   ubuntu: [ros-lunar-gazebo9-ros]
   debian: [ros-lunar-gazebo9-ros]
+gazebo_ros_control:
+  ubuntu: [ros-lunar-gazebo9-ros-control]
+  debian: [ros-lunar-gazebo9-ros-control]
 gazebo_ros_pkgs:
   ubuntu: [ros-lunar-gazebo9-ros-pkgs]
   debian: [ros-lunar-gazebo9-ros-pkgs]


### PR DESCRIPTION
Keys for gazebo8-ros-control are missing and needed for https://bitbucket.org/osrf/servicesim. I did a little sweep and added the keys for that package for each distro for gazebo8 and gazebo9.