### PR TITLE
Add rules to replace Gz Fortress with Gz Garden on Humble

### DIFF
--- a/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
+++ b/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
@@ -1,1 +1,2 @@
 yaml https://github.com/osrf/osrf-rosdep/raw/jrivero/rename_humble/gz/replace_fortress_with_garden/gz.yaml
+yaml https://github.com/osrf/osrf-rosdep/raw/jrivero/rename_humble/gz/replace_fortress_with_garden/releases/humble.yaml humble

--- a/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
+++ b/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
@@ -1,2 +1,2 @@
-yaml https://github.com/osrf/osrf-rosdep/raw/jrivero/rename_humble/gz/replace_fortress_with_garden/gz.yaml
-yaml https://github.com/osrf/osrf-rosdep/raw/jrivero/rename_humble/gz/replace_fortress_with_garden/releases/humble.yaml humble
+yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_garden/gz.yaml
+yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_garden/releases/humble.yaml humble

--- a/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
+++ b/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
@@ -1,0 +1,1 @@
+yaml https://github.com/osrf/osrf-rosdep/raw/jrivero/rename_humble/gz/replace_fortress_with_garden/gz.yaml

--- a/gz/replace_fortress_with_garden/gz.yaml
+++ b/gz/replace_fortress_with_garden/gz.yaml
@@ -1,6 +1,6 @@
 ---
 # Gazebo garden entries
-gz-garden:
+gz-fortress:
   ubuntu: [gz-garden]
 gz-cmake2:
   ubuntu: [libgz-cmake3-dev]

--- a/gz/replace_fortress_with_garden/gz.yaml
+++ b/gz/replace_fortress_with_garden/gz.yaml
@@ -42,3 +42,40 @@ sdformat12:
   ubuntu: [libsdformat13-dev]
 python3-sdformat12:
   ubuntu: [python3-sdformat13]
+# Ignition entries
+ignition-cmake2:
+  ubuntu: [libgz-cmake3-dev]
+ignition-common4:
+  ubuntu: [libgz-common5-dev]
+ignition-fuel-tools7:
+  ubuntu: [libgz-fuel-tools8-dev]
+ignition-sim6:
+  ubuntu: [libgz-sim7-dev]
+python3-ignition-sim6:
+  ubuntu: [python3-gz-sim7]
+ignition-gui6:
+  ubuntu: [libgz-gui7-dev]
+ignition-launch5:
+  ubuntu: [libgz-launch6-dev]
+ignition-math6:
+  ubuntu: [libgz-math7-dev]
+python3-ignition-math6:
+  ubuntu: [python3-gz-math7]
+ignition-msgs8:
+  ubuntu: [libgz-msgs9-dev]
+ignition-physics5:
+  ubuntu: [libgz-physics6-dev]
+ignition-plugin:
+  ubuntu: [libgz-plugin2-dev]
+ignition-rendering6:
+  ubuntu: [libgz-rendering7-dev]
+ignition-sensors6:
+  ubuntu: [libgz-sensors7-dev]
+ignition-tools:
+  ubuntu: [libgz-tools2-dev]
+ignition-transport11:
+  ubuntu: [libgz-transport12-dev]
+ignition-utils:
+  ubuntu: [libgz-utils2-dev]
+ignition-utils-cli:
+  ubuntu: [libgz-utils2-cli-dev]

--- a/gz/replace_fortress_with_garden/gz.yaml
+++ b/gz/replace_fortress_with_garden/gz.yaml
@@ -1,0 +1,44 @@
+---
+# Gazebo garden entries
+gz-garden:
+  ubuntu: [gz-garden]
+gz-cmake2:
+  ubuntu: [libgz-cmake3-dev]
+gz-common4:
+  ubuntu: [libgz-common5-dev]
+gz-fuel-tools7:
+  ubuntu: [libgz-fuel-tools8-dev]
+gz-sim6:
+  ubuntu: [libgz-sim7-dev]
+python3-gz-sim6:
+  ubuntu: [python3-gz-sim7]
+gz-gui6:
+  ubuntu: [libgz-gui7-dev]
+gz-launch5:
+  ubuntu: [libgz-launch6-dev]
+gz-math6:
+  ubuntu: [libgz-math7-dev]
+python3-gz-math6:
+  ubuntu: [python3-gz-math7]
+gz-msgs8:
+  ubuntu: [libgz-msgs9-dev]
+gz-physics5:
+  ubuntu: [libgz-physics6-dev]
+gz-plugin:
+  ubuntu: [libgz-plugin2-dev]
+gz-rendering6:
+  ubuntu: [libgz-rendering7-dev]
+gz-sensors6:
+  ubuntu: [libgz-sensors7-dev]
+gz-tools:
+  ubuntu: [libgz-tools2-dev]
+gz-transport11:
+  ubuntu: [libgz-transport12-dev]
+gz-utils:
+  ubuntu: [libgz-utils2-dev]
+gz-utils-cli:
+  ubuntu: [libgz-utils2-cli-dev]
+sdformat12:
+  ubuntu: [libsdformat13-dev]
+python3-sdformat12:
+  ubuntu: [python3-sdformat13]

--- a/gz/replace_fortress_with_garden/gz.yaml
+++ b/gz/replace_fortress_with_garden/gz.yaml
@@ -49,9 +49,9 @@ ignition-common4:
   ubuntu: [libgz-common5-dev]
 ignition-fuel-tools7:
   ubuntu: [libgz-fuel-tools8-dev]
-ignition-sim6:
+ignition-gazebo6:
   ubuntu: [libgz-sim7-dev]
-python3-ignition-sim6:
+python3-ignition-gazebo6:
   ubuntu: [python3-gz-sim7]
 ignition-gui6:
   ubuntu: [libgz-gui7-dev]

--- a/gz/replace_fortress_with_garden/releases/humble.yaml
+++ b/gz/replace_fortress_with_garden/releases/humble.yaml
@@ -1,0 +1,12 @@
+ros_gz:
+ ubuntu: [ros-humble-ros-gzgarden]
+ros_gz_bridge:
+ ubuntu: [ros-humble-ros-gzgarden-bridge]
+ros_gz_image:
+ ubuntu: [ros-humble-ros-gzgarden-image]
+ros_gz_interfaces:
+ ubuntu: [ros-humble-ros-gzgarden-interfaces]
+ros_gz_sim:
+ ubuntu: [ros-humble-ros-gzgarden-sim]
+ros_gz_sim_demos:
+ ubuntu: [ros-humble-ros-gzgarden-sim-demos]


### PR DESCRIPTION
The PR implements the option to use Garden instead of Fortress in ROS 2, particularly Humble:

 * The file `gz/replace_fortress_with_garden/gz.yaml` substitute all gz library versions from Fortress to the new ones in Garden by simply replace the rosdep conversion of Ubuntu packages (i.e: rosdep entry `gz-cmake2` will become `libgz-cmake3-dev` instead of the expected `libgz-cmake2-dev`)
 * The file `gz/replace_fortress_with_garden/releases/humble.yaml` rename the `ros_gz` packages for ROS 2 Humble using the rule: `-gz` to `-gzgarden` (i.e: `ros_gz_bridge` will be transformed to `ros-humble-ros-gzgarden-bridge` instead of the official ROS name `ros-humble-ros-gz-bridge`).
 * The file `gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list` is designed to be added to `/etc/ros/rosdep/sources.list.d/` to add the previous points to rosdep.
 
How to use (won't work out of the box since master needs to be replaced by the branch name):
```bash
wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list
rosdep update
rosdep resolve gz-fortress 
```
