### PR TITLE
Support for Iron renaming of Fortress to Garden

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ rosdep resolve gz-garden
 This repository has been used to help with redefinition of Gazebo rosdep keys when alternative binary packages were built to support "non default configurations". The alternative binary packages use a different name than the ones hosted in ROS repository so if they are in use inside a given ROS distributions, the user probably probably want the rosdep keys resolve to the new names.
 
 An example of this using Gazebo and ros_gz:
- * A ROS 2 Humble user requires Gazebo Garden instead of the officially support Gazebo Fortress
- * The ROS repository has `ros-humbe-ros-gz*` for Gazebo Fortress packages
- * Alternatives packages for Gazebo Garden were built and hosted in `packages.osrfoundation.org` named `ros-humble-ros-gzgarden-*`
+ * A ROS 2 Humble/Iron user requires Gazebo Garden instead of the officially support Gazebo Fortress
+ * The ROS repository has `ros-humbe-ros-gz*` or `ros-iron-ros-gz*` for Gazebo Fortress packages
+ * Alternatives packages for Gazebo Garden were built and hosted in `packages.osrfoundation.org` named `ros-humble-ros-gzgarden-*` or `ros-iron-ros-gzgarden-*`
  * Support for renaming was implemented in #12
 
 Another old example of this for Gazebo Classic:

--- a/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
+++ b/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
@@ -1,3 +1,3 @@
 yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_garden/gz.yaml
 yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_garden/releases/humble.yaml humble
-yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_garden/releases/humble.yaml iron
+yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_garden/releases/iron.yaml iron

--- a/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
+++ b/gz/replace_fortress_with_garden/00-replace-gz-fortress-with-garden.list
@@ -1,2 +1,3 @@
 yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_garden/gz.yaml
 yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_garden/releases/humble.yaml humble
+yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_garden/releases/humble.yaml iron

--- a/gz/replace_fortress_with_garden/releases/iron.yaml
+++ b/gz/replace_fortress_with_garden/releases/iron.yaml
@@ -1,0 +1,12 @@
+ros_gz:
+ ubuntu: [ros-iron-ros-gzgarden]
+ros_gz_bridge:
+ ubuntu: [ros-iron-ros-gzgarden-bridge]
+ros_gz_image:
+ ubuntu: [ros-iron-ros-gzgarden-image]
+ros_gz_interfaces:
+ ubuntu: [ros-iron-ros-gzgarden-interfaces]
+ros_gz_sim:
+ ubuntu: [ros-iron-ros-gzgarden-sim]
+ros_gz_sim_demos:
+ ubuntu: [ros-iron-ros-gzgarden-sim-demos]


### PR DESCRIPTION
Add support for ROS 2 Iron for renaming Gazebo Fortress packages to Gazebo Garden.
