### PR TITLE
Add rules to replace Gz Fortress with Gz Harmonic on Humble/Iron

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,20 @@ rosdep resolve gz-harmonic
 
 ## 2. Redefine rosdep keys affecting Gazebo packages to point to alternative binaries
 
-This repository has been used to help with redefinition of Gazebo rosdep keys when alternative binary packages were built to support "non default configurations". The alternative binary packages use a different name than the ones hosted in ROS repository so if they are in use inside a given ROS distributions, the user probably probably want the rosdep keys resolve to the new names.
+This repository has been used to help with redefinition of Gazebo rosdep keys when alternative binary packages were built to support "non default configurations".
+The alternative binary packages use a different name than the ones hosted in ROS repository so if they are in use inside a given ROS distributions, the user probably probably want the rosdep keys resolve to the new names.
 
-An example of this using Gazebo and ros_gz:
+Example of this using Gazebo Garden and ros_gz:
  * A ROS 2 Humble/Iron user requires Gazebo Garden instead of the officially support Gazebo Fortress
  * The ROS repository has `ros-humbe-ros-gz*` or `ros-iron-ros-gz*` for Gazebo Fortress packages
  * Alternatives packages for Gazebo Garden were built and hosted in `packages.osrfoundation.org` named `ros-humble-ros-gzgarden-*` or `ros-iron-ros-gzgarden-*`
- * Support for renaming was implemented in #12
+ * Support and instructions for renaming are in #12
 
-Another old example of this for Gazebo Classic:
- * A ROS 2 Dashing user requires Gazebo11 instead of the officially supported Gazebo9
- * The ROS repository has `ros-dashing-gazebo-ros-*` for Gazebo9 packages
- * Alternatives packages for Gazebo11 were built and hosted in `packages.osrfoundation.org` named `ros-dashing-gazebo11-ros-*`
- * Support for renaming was added to this repository in https://github.com/osrf/osrf-rosdep/commit/7f456cc26039e8679951218893d2ec74a679c139
+**Note:** wait until the official release of Harmonic
+Example of this using Gazebo Harmonic and ros_gz:
+ * A ROS 2 Humble/Iron user requires Gazebo Harmonic instead of the officially support Gazebo Fortress
+ * The ROS repository has `ros-humbe-ros-gz*` or `ros-iron-ros-gz*` for Gazebo Fortress packages
+ * Alternatives packages for Gazebo Harmonic were built and hosted in `packages.osrfoundation.org` named `ros-humble-ros-gzgarden-*` or `ros-iron-ros-gzgarden-*`
+ * Support and instructions for renaming are in #16
 
 The decission of building unofficial Gazebo binaries is made by the Gazebo simulation team. There are currently no alternative packages of any Gazebo distribution supported at this time.

--- a/gz/replace_fortress_with_harmonic/00-replace-gz-fortress-with-harmonic.list
+++ b/gz/replace_fortress_with_harmonic/00-replace-gz-fortress-with-harmonic.list
@@ -1,0 +1,3 @@
+yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_harmonic/gz.yaml
+yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_harmonic/releases/humble.yaml humble
+yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_fortress_with_harmonic/releases/iron.yaml iron

--- a/gz/replace_fortress_with_harmonic/releases/humble.yaml
+++ b/gz/replace_fortress_with_harmonic/releases/humble.yaml
@@ -1,0 +1,12 @@
+ros_gz:
+ ubuntu: [ros-humble-ros-gzharmonic]
+ros_gz_bridge:
+ ubuntu: [ros-humble-ros-gzharmonic-bridge]
+ros_gz_image:
+ ubuntu: [ros-humble-ros-gzharmonic-image]
+ros_gz_interfaces:
+ ubuntu: [ros-humble-ros-gzharmonic-interfaces]
+ros_gz_sim:
+ ubuntu: [ros-humble-ros-gzharmonic-sim]
+ros_gz_sim_demos:
+ ubuntu: [ros-humble-ros-gzharmonic-sim-demos]

--- a/gz/replace_fortress_with_harmonic/releases/iron.yaml
+++ b/gz/replace_fortress_with_harmonic/releases/iron.yaml
@@ -1,0 +1,12 @@
+ros_gz:
+ ubuntu: [ros-iron-ros-gzharmonic]
+ros_gz_bridge:
+ ubuntu: [ros-iron-ros-gzharmonic-bridge]
+ros_gz_image:
+ ubuntu: [ros-iron-ros-gzharmonic-image]
+ros_gz_interfaces:
+ ubuntu: [ros-iron-ros-gzharmonic-interfaces]
+ros_gz_sim:
+ ubuntu: [ros-iron-ros-gzharmonic-sim]
+ros_gz_sim_demos:
+ ubuntu: [ros-iron-ros-gzharmonic-sim-demos]


### PR DESCRIPTION
The PR implements the option to use Harmonic instead of Fortress in ROS 2, particularly Humble:

 * The file `gz/replace_fortress_with_harmonic/gz.yaml` substitute all gz library versions from Fortress to the new ones in harmonic by simply replace the rosdep conversion of Ubuntu packages (i.e: rosdep entry `gz-cmake2` will become `libgz-cmake3-dev` instead of the expected `libgz-cmake2-dev`)
 * The file `gz/replace_fortress_with_harmonic/releases/humble.yaml` rename the `ros_gz` packages for ROS 2 Humble using the rule: `-gz` to `-gzharmonic` (i.e: `ros_gz_bridge` will be transformed to `ros-humble-ros-gzharmonic-bridge` instead of the official ROS name `ros-humble-ros-gz-bridge`).
 * The file `gz/replace_fortress_with_harmonic/00-replace-gz-fortress-with-harmonic.list` is designed to be added to `/etc/ros/rosdep/sources.list.d/` to add the previous points to rosdep.
 
How to use:
```bash
wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/replace_fortress_with_harmonic/00-replace-gz-fortress-with-harmonic.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list
rosdep update
rosdep resolve gz-fortress 
```

