### PR TITLE
Add replace Garden with Harmonic

### DIFF
--- a/gz/replace_garden_with_harmonic/00-replace-gz-garden-with-harmonic.list
+++ b/gz/replace_garden_with_harmonic/00-replace-gz-garden-with-harmonic.list
@@ -1,0 +1,3 @@
+yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_garden_with_harmonic/gz.yaml
+yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_garden_with_harmonic/releases/humble.yaml humble
+yaml https://github.com/osrf/osrf-rosdep/raw/master/gz/replace_garden_with_harmonic/releases/iron.yaml iron

--- a/gz/replace_garden_with_harmonic/gz.yaml
+++ b/gz/replace_garden_with_harmonic/gz.yaml
@@ -1,0 +1,45 @@
+---
+# Gazebo Harmonic entries
+gz-garden:
+  ubuntu: [gz-harmonic]
+gz-fuel-tools8:
+  ubuntu: [libgz-fuel-tools9-dev]
+gz-sim7:
+  ubuntu: [libgz-sim8-dev]
+python3-gz-sim7:
+  ubuntu: [python3-gz-sim8]
+gz-gui7:
+  ubuntu: [libgz-gui8-dev]
+gz-msgs9:
+  ubuntu: [libgz-msgs10-dev]
+gz-physics6:
+  ubuntu: [libgz-physics7-dev]
+gz-rendering7:
+  ubuntu: [libgz-rendering8-dev]
+gz-sensors7:
+  ubuntu: [libgz-sensors8-dev]
+gz-transport12:
+  ubuntu: [libgz-transport13-dev]
+sdformat13:
+  ubuntu: [libsdformat14-dev]
+python3-sdformat13:
+  ubuntu: [python3-sdformat14]
+# Ignition entries
+ignition-fuel-tools8:
+  ubuntu: [libgz-fuel-tools9-dev]
+ignition-gazebo7:
+  ubuntu: [libgz-sim8-dev]
+python3-ignition-gazebo7:
+  ubuntu: [python3-gz-sim8]
+ignition-gui7:
+  ubuntu: [libgz-gui8-dev]
+ignition-msgs9:
+  ubuntu: [libgz-msgs10-dev]
+ignition-physics6:
+  ubuntu: [libgz-physics7-dev]
+ignition-rendering7:
+  ubuntu: [libgz-rendering8-dev]
+ignition-sensors7:
+  ubuntu: [libgz-sensors8-dev]
+ignition-transport12:
+  ubuntu: [libgz-transport13-dev]

--- a/gz/replace_garden_with_harmonic/releases
+++ b/gz/replace_garden_with_harmonic/releases
@@ -1,0 +1,1 @@
+../replace_fortress_with_harmonic/releases/


### PR DESCRIPTION
This is a weird case since Garden is not the official release of any ROS distribution up to date. However when releasing `ros_gz` the default version in `ros2` branch points to Garden packages versions and relies on the `GZ_VERSION` var for handling the different Gazebo collections when building from source. This is fine if not using bloom, which does not support the injection of environment variables so we need to use this trick of replace rosdep keys.
