### PR TITLE
Change DART key to point to packages.osrfoundation.org 6.16

### DIFF
--- a/gz/gazebo.yaml
+++ b/gz/gazebo.yaml
@@ -1,8 +1,6 @@
 ---
 # Common dependencies
 DART:  # only from packages.osrfoundation.org
-  ubuntu: [libdart6.13-dev]
-DART-6.16:  # only from packages.osrfoundation.org
   ubuntu: [libdart6.16-dev]
 libogre-next-2.3-dev: # only from packages.osrfoundation.org
   ubuntu: [libogre-next-2.3-dev]

--- a/gz/gazebo.yaml
+++ b/gz/gazebo.yaml
@@ -1,7 +1,9 @@
 ---
 # Common dependencies
-DART:
-  ubuntu: [libdart-dev]
+DART:  # only from packages.osrfoundation.org
+  ubuntu: [libdart6.13-dev]
+DART-6.16:  # only from packages.osrfoundation.org
+  ubuntu: [libdart6.16-dev]
 libogre-next-2.3-dev: # only from packages.osrfoundation.org
   ubuntu: [libogre-next-2.3-dev]
 libzenohc-dev: # only from packages.osrfoundation.org


### PR DESCRIPTION
The current setup of this repository to resolve DART key to the default in Ubuntu is broken https://build.osrfoundation.org/job/ci__colcon_any-manual_ubuntu_noble_amd64/61/console.

Doing a breaking change here since I think that there is no option for previous users of this osrf-rosdep to get the DART right for Gazebo so I'm defaulting to 6.13 and consider a bug-fix and not a feature change.

Added the DART-6.16 to resolve to the upcoming new package.